### PR TITLE
(#14) CommandLinkProvider: enable during dumb mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) a
 - The minimal IntelliJ version required is now 2022.2.
 - Default link highlighting is now combined from hyperlink and "Command to run using IDE".
 - The plugin no longer hijacks links to non-executable files.
+- The filter is now available during indexing as well.
 
 ### Added
 - Balloon notifications about script termination states.

--- a/src/main/kotlin/CommandLinkProvider.kt
+++ b/src/main/kotlin/CommandLinkProvider.kt
@@ -8,6 +8,7 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.editor.colors.CodeInsightColors
 import com.intellij.openapi.editor.colors.EditorColorsManager
 import com.intellij.openapi.editor.markup.TextAttributes
+import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.terminal.JBTerminalSystemSettingsProviderBase
@@ -29,7 +30,7 @@ class CommandLinkProvider : ConsoleFilterProvider {
     inner class CommandLinkFilter(
         private val editorColorsManager: Lazy<EditorColorsManager>,
         private val commandExecutor: Lazy<CommandExecutor>
-    ) : Filter {
+    ) : Filter, DumbAware {
 
         constructor(project: Project) : this(
             lazy { EditorColorsManager.getInstance() },


### PR DESCRIPTION
Closes #14.