### PR TITLE
(#31) Tool window management: base new logic upon RunContentManager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] (1.0.1)
+### Fixed
+- [#31: The progress is never removed](https://github.com/ForNeVeR/file-link-executor/issues/31).
+
 ## [1.0.0] - 2022-11-22
 ### Changed
 - The tabs for started processes were moved to the standard **Run** tool window.

--- a/src/main/kotlin/me/fornever/filelinkexecutor/CommandExecutor.kt
+++ b/src/main/kotlin/me/fornever/filelinkexecutor/CommandExecutor.kt
@@ -51,24 +51,17 @@ class CommandExecutor(
         val programName = program.name
 
         val console = textConsoleBuilderFactory.value.createBuilder(project).console
-        val (processHandler, descriptor) = startProcess(cmd, programName, console)
-        val listener = attachExecutionListener(processHandler, programName, console, descriptor)
-        startProgressIndicator(listener, programName)
-
-        console.attachToProcess(processHandler)
-        processHandler.startNotify()
-    }
-
-    private data class RunResult(val processHandler: ProcessHandler, val contentDescriptor: RunContentDescriptor)
-    private fun startProcess(command: GeneralCommandLine, programName: String, console: ConsoleView): RunResult {
-        val processHandler = processHandlerFactory.value.createProcessHandler(command)
+        val processHandler = processHandlerFactory.value.createProcessHandler(cmd)
         val descriptor = executionToolWindowManager.value.addTab(
             processHandler,
             console,
             programName
         )
+        val listener = attachExecutionListener(processHandler, programName, console, descriptor)
+        startProgressIndicator(listener, programName)
 
-        return RunResult(processHandler, descriptor)
+        console.attachToProcess(processHandler)
+        processHandler.startNotify()
     }
 
     private fun attachExecutionListener(

--- a/src/main/kotlin/me/fornever/filelinkexecutor/ExecutionToolWindowManager.kt
+++ b/src/main/kotlin/me/fornever/filelinkexecutor/ExecutionToolWindowManager.kt
@@ -1,36 +1,35 @@
 package me.fornever.filelinkexecutor
 
+import com.intellij.execution.Executor
+import com.intellij.execution.executors.DefaultRunExecutor
 import com.intellij.execution.process.OSProcessHandler
-import com.intellij.execution.process.ProcessHandler
-import com.intellij.execution.ui.ConsoleView
+import com.intellij.execution.ui.ExecutionConsole
+import com.intellij.execution.ui.RunContentDescriptor
+import com.intellij.execution.ui.RunContentManager
+import com.intellij.openapi.Disposable
 import com.intellij.openapi.components.Service
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.MessageType
-import com.intellij.openapi.util.Disposer
-import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowBalloonShowOptions
-import com.intellij.openapi.wm.ToolWindowId
 import com.intellij.openapi.wm.ToolWindowManager
-import com.intellij.ui.content.Content
-import com.intellij.ui.content.ContentManagerEvent
-import com.intellij.ui.content.ContentManagerListener
 import com.intellij.util.concurrency.annotations.RequiresEdt
-
-private const val TOOL_WINDOW_ID = ToolWindowId.RUN
 
 @Service(Service.Level.PROJECT)
 class ExecutionToolWindowManager(
+    private val runContentManager: Lazy<RunContentManager>,
+    private val executor: Lazy<Executor>,
     private val toolWindowManager: Lazy<ToolWindowManager>
-) {
-
-    private data class ContentTab(val process: ProcessHandler, val console: ConsoleView, val content: Content)
-    private val contentTabs = mutableListOf<ContentTab>()
+) : Disposable {
 
     @Suppress("unused")
     constructor(project: Project) : this(
+        lazy { RunContentManager.getInstance(project) },
+        lazy { DefaultRunExecutor.getRunExecutorInstance() },
         lazy { ToolWindowManager.getInstance(project) }
     )
+
+    override fun dispose() {}
 
     companion object {
         fun getInstance(project: Project): ExecutionToolWindowManager = project.service()
@@ -41,54 +40,25 @@ class ExecutionToolWindowManager(
      * or creates a new tab in the Run tool window.
      */
     @RequiresEdt
-    fun addTab(process: OSProcessHandler, console: ConsoleView, tabName: String) {
-        val contentIndexToReplace = getContentToReplace()
-        if (contentIndexToReplace == null) {
-            val toolWindow = getToolWindow()
-            val content = toolWindow.contentManager.factory.createContent(console.component, tabName, true)
+    fun addTab(process: OSProcessHandler, console: ExecutionConsole, tabName: String): RunContentDescriptor {
+        val contentDescriptor = RunContentDescriptor(console, process, console.component, tabName)
 
-            contentTabs.add(ContentTab(process, console, content))
-            toolWindow.contentManager.addContent(content)
-        } else {
-            val (_, oldConsole, oldContent) = contentTabs[contentIndexToReplace]
-            oldContent.component = console.component
-            oldContent.tabName = tabName
-            Disposer.dispose(oldConsole)
-            contentTabs[contentIndexToReplace] = ContentTab(process, console, oldContent)
-        }
+        runContentManager.value.showRunContent(
+            executor.value,
+            contentDescriptor
+        )
+
+        return contentDescriptor
     }
 
     @RequiresEdt
-    fun notifyByBalloon(messageType: MessageType, text: String) {
+    fun notifyByBalloon(descriptor: RunContentDescriptor, messageType: MessageType, text: String) {
+        val toolWindow = runContentManager.value.getToolWindowByDescriptor(descriptor) ?: return
         val balloon = ToolWindowBalloonShowOptions(
-            TOOL_WINDOW_ID,
+            toolWindow.id,
             messageType,
             text
         )
         toolWindowManager.value.notifyByBalloon(balloon)
-    }
-
-    private fun getToolWindow(): ToolWindow {
-        val toolWindow = toolWindowManager.value.getToolWindow(TOOL_WINDOW_ID)
-            ?: error("Cannot find tool window with id \"$TOOL_WINDOW_ID\"")
-        toolWindow.addContentManagerListener(object : ContentManagerListener {
-            @RequiresEdt
-            override fun contentRemoved(event: ContentManagerEvent) {
-                val content = event.content
-                val index = contentTabs.indexOfFirst { (_, _, c) -> c == content }
-                if (index != -1) {
-                    val (_, console, _) = contentTabs.removeAt(index)
-                    Disposer.dispose(console)
-                }
-            }
-        })
-        return toolWindow
-    }
-
-    private fun getContentToReplace(): Int? {
-        val index = contentTabs.indexOfFirst { (process, _, content) ->
-            process.isProcessTerminated && !content.isPinned
-        }
-        return if (index == -1) null else index
     }
 }


### PR DESCRIPTION
This will allow us to use the Run tool window even if it isn't constructed at the moment.

Closes #31.